### PR TITLE
Fix Docker build push conflict in GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,8 +55,6 @@ jobs:
       with:
         context: .
         platforms: linux/amd64
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
@@ -105,8 +103,6 @@ jobs:
       with:
         context: .
         platforms: linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was failing for both ARM64 and AMD64 builds with the error:
```
ERROR: failed to solve: failed to push ghcr.io/denysvitali/openhands-runtime-go:master: can't push tagged ref ghcr.io/denysvitali/openhands-runtime-go:master by digest
```

## Root Cause
The workflow was trying to push Docker images both by digest and with tags simultaneously in the individual build steps, which creates a conflict. The `push-by-digest=true` option was being used alongside `tags` and `push` parameters.

## Solution
- Removed `tags` and `push` parameters from individual AMD64 and ARM64 build steps
- Keep only digest-based pushing for the individual builds
- Let the `create-manifest` step handle the final tagging and manifest creation
- This follows the proper multi-platform build pattern where individual builds push by digest only, and the manifest step combines them with proper tags

## Changes
- Modified `.github/workflows/docker.yml` to remove conflicting push configurations
- Individual builds now only push by digest
- Manifest creation step handles final tagging as intended

This should resolve the build failures and allow successful multi-platform Docker image builds.