### PR TITLE
Fix: Remove duplicate ListFilesRequest struct

### DIFF
--- a/internal/models/observation.go
+++ b/internal/models/observation.go
@@ -98,10 +98,6 @@ type UploadResponse struct {
 	Path    string `json:"path"`
 }
 
-// ListFilesRequest represents a file listing request
-type ListFilesRequest struct {
-	Path string `json:"path,omitempty"`
-}
 
 // VSCodeConnectionToken represents VSCode connection token
 type VSCodeConnectionToken struct {


### PR DESCRIPTION
This PR removes a duplicate definition of the `ListFilesRequest` struct from `internal/models/observation.go`. This was causing a build failure.