### PR TITLE
Fix telemetry schema URL conflict by updating semconv to v1.26.0

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -17,7 +17,7 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // Initialize sets up OpenTelemetry tracing and logging using autoexport


### PR DESCRIPTION
## Problem

The application was failing to initialize telemetry with the following error:
```
Failed to initialize telemetry: conflicting Schema URL: https://opentelemetry.io/schemas/1.26.0 and https://opentelemetry.io/schemas/1.24.0
```

This was caused by a version mismatch between the semconv package (v1.24.0) and the main OpenTelemetry packages (v1.36.0).

## Solution

Updated the semconv import from `v1.24.0` to `v1.26.0` to align with the schema version used by OpenTelemetry v1.36.0 packages.

## Changes

- Updated `pkg/telemetry/telemetry.go` to import `go.opentelemetry.io/otel/semconv/v1.26.0` instead of `v1.24.0`

## Testing

- ✅ Application now starts without telemetry warnings
- ✅ Server runs successfully on port 8000
- ✅ Build completes without errors
- ✅ All telemetry functionality works as expected

## Impact

- Resolves the schema URL conflict error
- Ensures compatibility with the current OpenTelemetry package versions
- No breaking changes to the API or functionality