### PR TITLE
Fix IPython observation type to match OpenHands server expectations

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -329,7 +329,7 @@ func (e *Executor) executeIPython(ctx context.Context, action models.IPythonRunC
 
 	// This is a placeholder - in a real implementation you'd integrate with Jupyter
 	return models.IPythonRunCellObservation{
-		Observation: "ipython",
+		Observation: "run_ipython",
 		Content:     "IPython execution not implemented in Go runtime",
 		Code:        action.Code,
 		Timestamp:   time.Now(),


### PR DESCRIPTION
## Problem

The OpenHands server was failing to initialize agent sessions with the following error:

```
KeyError: "'observation['observation']='ipython'' is not defined. Available observations: dict_keys([<ObservationType.NULL: 'null'>, <ObservationType.RUN: 'run'>, <ObservationType.RUN_IPYTHON: 'run_ipython'>, <ObservationType.BROWSE: 'browse'>, <ObservationType.READ: 'read'>, <ObservationType.WRITE: 'write'>, <ObservationType.EDIT: 'edit'>, <ObservationType.DELEGATE: 'delegate'>, <ObservationType.SUCCESS: 'success'>, <ObservationType.ERROR: 'error'>, <ObservationType.AGENT_STATE_CHANGED: 'agent_state_changed'>, <ObservationType.USER_REJECTED: 'user_rejected'>, <ObservationType.CONDENSE: 'condense'>, <ObservationType.THINK: 'think'>, <ObservationType.RECALL: 'recall'>, <ObservationType.MCP: 'mcp'>])"
```

## Root Cause

The Go runtime was returning IPython observations with the observation type `"ipython"`, but the OpenHands server expects `"run_ipython"` based on its defined observation types.

## Solution

- Changed the observation type in `executeIPython` function from `"ipython"` to `"run_ipython"`
- This aligns with the expected observation types defined in the OpenHands server
- Maintains compatibility with the action type `"run_ipython"` that was already correctly implemented

## Changes

- **File**: `pkg/executor/executor.go`
- **Line 332**: Changed `Observation: "ipython"` to `Observation: "run_ipython"`

## Testing

- ✅ Code compiles successfully
- ✅ All other observation types remain consistent with server expectations
- ✅ Verified the fix with a test that confirms the observation type is now correct

## Impact

This fix resolves the runtime initialization error and allows the OpenHands server to properly communicate with the Go runtime for IPython code execution actions.