### PR TITLE
feat: Add npm, fix Nix, and implement file read limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,10 @@ RUN apk --no-cache add \
     vim \
     nano \
     kubectl \
+\
     helm
+    nodejs
+    npm
 
 # Install Bazel (not available as Alpine package)
 RUN BAZEL_VERSION=$(wget -qO- https://api.github.com/repos/bazelbuild/bazel/releases/latest | grep '"tag_name"' | cut -d'"' -f4) && \
@@ -75,8 +78,8 @@ ENV PATH="/home/openhands/go/bin:${PATH}"
 
 RUN addgroup -g 1001 -S openhands && \
     adduser -u 1001 -S openhands -G openhands && \
-    mkdir -p /app /openhands/code /home/openhands/go/bin && \
-    chown -R openhands:openhands /app /openhands/code /home/openhands
+    mkdir -p /app /openhands/code /home/openhands/go/bin /nix && \
+    chown -R openhands:openhands /app /openhands/code /home/openhands /nix
 
 WORKDIR /openhands/code
 
@@ -85,7 +88,12 @@ COPY --from=builder /app/openhands-runtime-go /app/
 # Set up Go workspace for the openhands user
 USER openhands
 RUN go env -w GOPATH=/home/openhands/go && \
-    go env -w GOBIN=/home/openhands/go/bin
+    go env -w GOBIN=/home/openhands/go/bin && \
+    # Initialize Nix channels
+    nix-channel --add https://nixos.org/channels/nixpkgs-unstable && \
+    nix-channel --update && \
+    # Warm up Nix by installing a small package
+    nix-env -iA nixpkgs.hello
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,8 @@ RUN apk --no-cache add \
     vim \
     nano \
     kubectl \
-\
-    helm
-    nodejs
+    helm \
+    nodejs \
     npm
 
 # Install Bazel (not available as Alpine package)


### PR DESCRIPTION
- Add Node.js and npm to the Dockerfile.
- Modify Dockerfile to correctly initialize Nix for the openhands user.
- Update Go file reading action to truncate content based on MAX_FILE_READ_CHARS (default 5000) and notify if truncated.