### PR TITLE
Remove file truncation and add max file size check

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type ServerConfig struct {
 	FileViewerPort     int      `mapstructure:"file_viewer_port"`
 	MaxMemoryGB        int      `mapstructure:"max_memory_gb"`
 	NoChangeTimeoutSec int      `mapstructure:"no_change_timeout_seconds"`
+	MaxFileSize        int64    `mapstructure:"max_file_size"`
 }
 
 // TelemetryConfig contains telemetry configuration
@@ -68,6 +69,7 @@ func setDefaults() {
 	viper.SetDefault("server.file_viewer_port", 0) // Auto-assign
 	viper.SetDefault("server.max_memory_gb", 0)    // No limit
 	viper.SetDefault("server.no_change_timeout_seconds", 10)
+	viper.SetDefault("server.max_file_size", 50*1024) // 50KB
 
 	// Telemetry defaults
 	viper.SetDefault("telemetry.enabled", true)

--- a/pkg/executor/file_management.go
+++ b/pkg/executor/file_management.go
@@ -171,6 +171,18 @@ func (e *Executor) DownloadFile(ctx context.Context, path string) ([]byte, error
 
 	resolvedPath := e.resolvePath(path)
 
+	fileInfo, err := os.Stat(resolvedPath)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	if fileInfo.Size() > e.config.Server.MaxFileSize {
+		err := fmt.Errorf("file size (%d bytes) exceeds maximum allowed size (%d bytes)", fileInfo.Size(), e.config.Server.MaxFileSize)
+		span.RecordError(err)
+		return nil, err
+	}
+
 	content, err := os.ReadFile(resolvedPath)
 	if err != nil {
 		span.RecordError(err)

--- a/pkg/executor/file_operations.go
+++ b/pkg/executor/file_operations.go
@@ -192,27 +192,8 @@ func (e *Executor) executeFileRead(ctx context.Context, action models.FileReadAc
 		}
 	}
 
-	// Truncate content if it exceeds the maximum allowed length
-	maxFileReadCharsStr := os.Getenv("MAX_FILE_READ_CHARS")
-	maxFileReadChars, errConv := strconv.Atoi(maxFileReadCharsStr)
-	if errConv != nil || maxFileReadChars <= 0 {
-		maxFileReadChars = 5000 // Default value
-	}
-
-	truncated := false
-	if len(contentStr) > maxFileReadChars {
-		contentStr = contentStr[:maxFileReadChars]
-		truncated = true
-		e.logger.Infof("File content truncated to %d characters for path: %s", maxFileReadChars, path)
-	}
-
-	finalContent := contentStr
-	if truncated {
-		finalContent += "\n... (file truncated)"
-	}
-
-	e.logger.Debugf("Successfully read file: %s (%d bytes, truncated: %v)", path, len(finalContent), truncated)
-	return models.NewFileReadObservation(finalContent, action.Path), nil
+	e.logger.Debugf("Successfully read file: %s (%d bytes)", path, len(contentStr))
+	return models.NewFileReadObservation(contentStr, action.Path), nil
 }
 
 // executeFileWrite writes to a file

--- a/pkg/executor/file_operations.go
+++ b/pkg/executor/file_operations.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"strconv"
 
 	"go.opentelemetry.io/otel/attribute"
 


### PR DESCRIPTION
This pull request introduces a new configuration parameter to limit file size and updates related functionality to enforce this limit. The changes include adding the `MaxFileSize` parameter, validating file size during file downloads, and removing redundant file content truncation logic.

### Configuration Updates:
* [`pkg/config/config.go`](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R29): Added a new `MaxFileSize` parameter to the `ServerConfig` struct and set its default value to 50KB in the `setDefaults` function. [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R29) [[2]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R72)

### File Size Validation:
* [`pkg/executor/file_management.go`](diffhunk://#diff-4690c611faf806503672e4b35580661f2cb9f146911dafe5249929b0d49b840eR174-R185): Updated the `DownloadFile` method to check the size of the file against the `MaxFileSize` limit and return an error if the file exceeds the allowed size.

### Code Simplification:
* [`pkg/executor/file_operations.go`](diffhunk://#diff-02a462674923d89972a271d8098035b83353440da798a361b99b7d0861b6113bL195-R196): Removed logic for truncating file content based on a character limit, as file size is now enforced through the `MaxFileSize` parameter.